### PR TITLE
Add Kokkos build without Cuda

### DIFF
--- a/cctbx/perlmutter_environment.yml
+++ b/cctbx/perlmutter_environment.yml
@@ -78,3 +78,7 @@ dependencies:
 
 # perlmutter
  - libglu
+
+ # temporarily pin numpy version
+ # See https://github.com/cctbx/cctbx_project/issues/627
+ - numpy=1.20

--- a/cctbx/psana_environment.yml
+++ b/cctbx/psana_environment.yml
@@ -80,3 +80,7 @@ dependencies:
  - scikit-learn
  - pandas
  - pydrive2
+
+ # temporarily pin numpy version
+ # See https://github.com/cctbx/cctbx_project/issues/627
+ - numpy=1.20

--- a/cctbx/utilities.sh
+++ b/cctbx/utilities.sh
@@ -132,6 +132,17 @@ mk-cctbx () {
                             --config-flags="--enable_openmp_if_possible=True" \
                             --config-flags="--enable_cuda" \
                             ${@:2}
+    elif [[ $1 == "kokkos" ]]
+    then
+        python bootstrap.py --builder=dials \
+                            --python=37 \
+                            --use-conda ${CONDA_PREFIX} \
+                            --nproc=${NPROC:-8} \
+                            --config-flags="--enable_cxx11" \
+                            --config-flags="--no_bin_python" \
+                            --config-flags="--enable_openmp_if_possible=True" \
+                            --config-flags="--enable_kokkos" \
+                            ${@:2}
     fi
     popd
 }


### PR DESCRIPTION
- add a new 'kokkos' option to 'mk-cctbx'. Use case: "mk-cctbx kokkos build"
- this also fixes the numpy version to 1.20 as numpy 1.21 leads to segmentation faults (see also cctbx #627)