### PR TITLE
Unpin wxpython to match cctbx_project 89fa3009

### DIFF
--- a/cctbx/perlmutter_environment.yml
+++ b/cctbx/perlmutter_environment.yml
@@ -38,7 +38,7 @@ dependencies:
  - pillow
  - reportlab
  # - wxpython
- - wxpython=4.0.*
+ - wxpython
  - pyopengl
  - libtiff
 


### PR DESCRIPTION
The pinned wxpython was resulting in an old psana version that
no longer worked for the epix10k detector