### PR TITLE
Add natsort to psana and perlmutter environment yamls

### DIFF
--- a/cctbx/perlmutter_environment.yml
+++ b/cctbx/perlmutter_environment.yml
@@ -1,11 +1,12 @@
 name: psana_env
 channels:
- - defaults
  - lcls-i
  - conda-forge
  - cctbx
  - pytorch
  - nvidia
+ - nodefaults
+
 dependencies:
 # Don't do these -- they interfere with NERSC systems
 # # conda compilers

--- a/cctbx/perlmutter_environment.yml
+++ b/cctbx/perlmutter_environment.yml
@@ -71,6 +71,9 @@ dependencies:
  - dials-data
  - gemmi
 
+ # dxtbx
+ - natsort
+
  # xia2
  - tabulate
 

--- a/cctbx/psana_environment.yml
+++ b/cctbx/psana_environment.yml
@@ -1,9 +1,10 @@
 name: psana_env
 channels:
- - defaults
  - lcls-i
  - conda-forge
  - cctbx
+ - nodefaults
+
 dependencies:
 # Don't do these -- they interfere with NERSC systems
 # # conda compilers

--- a/cctbx/psana_environment.yml
+++ b/cctbx/psana_environment.yml
@@ -65,6 +65,9 @@ dependencies:
  - dials-data
  - gemmi
 
+ # dxtbx
+ - natsort
+
  # xia2
  - tabulate
 


### PR DESCRIPTION
Similarly to `gemmi`, it seems this package also needs to be manually added to `alcc-recipes` for `dxtbx` to work correctly. I will check this in a moment, and in the meantime anyone who gets `ModuleNotFoundError: No module named 'natsort'` should be able to circumvent it by using the last natsort-less commit in dxtbx: `git checkout e684c41f38405a23c217c250de76066ee509f3b3`.